### PR TITLE
Fix GraphQL query arguments for entries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "studioespresso/craft-date-range",
     "description": "Date range field",
     "type": "craft-plugin",
-    "version": "5.0.0-beta.2",
+    "version": "5.0.0-beta.3",
     "keywords": [
         "craft",
         "cms",

--- a/src/gql/types/DateRangeType.php
+++ b/src/gql/types/DateRangeType.php
@@ -44,8 +44,10 @@ class DateRangeType extends ObjectType
                 break;
 
             case 'isOnGoing':
-                return $source->isOnGoing;
+            case 'isOngoing':
+                return $source->isOngoing;
                 break;
+
             default:
                 return $source->$fieldName;
                 break;


### PR DESCRIPTION
This PR addresses some issues with the GraphQL API.

1. Fix [error thrown](https://github.com/studioespresso/craft-date-range/issues/38) when querying entries based on a Date Range field, via the following Query argument methods:
- studioespresso\daterange\behaviors\EntryQueryBehaviour::isFuture()`
- studioespresso\daterange\behaviors\EntryQueryBehaviour::isPast()`
- studioespresso\daterange\behaviors\EntryQueryBehaviour::isNotPast()`
- studioespresso\daterange\behaviors\EntryQueryBehaviour::isOngoing()`

When used in a GraphQL query, only 1 array argument is given to those methods, which was thowing an error in the Craft v5 version because the methods require 2 arguments (date range field `handle` and `entryTypeHandle`). This PR fixes this by making the 2nd argument optional, and extracts it from the 1st array argument instead. Fixes #38

2. Fix typo in the `isOngoing` field on the GraphQL data type returned for Date Range fields.

---

Note: We are using our fork with the fixes above on one of our projects, and so far it is working well :).